### PR TITLE
fix of Notice: Undefined index: Address1

### DIFF
--- a/sdk/src/core/Soap/Order/GetOrderListResponse.php
+++ b/sdk/src/core/Soap/Order/GetOrderListResponse.php
@@ -187,13 +187,20 @@ class GetOrderListResponse extends iResponse
     }
 
     /**
-     * Retrieve <BillingAddress> Balise
+     * Retrieve <BillingAddress|ShippingAddress> Balise
      *
      * @param $objAddressResult
-     * @return Address
+     * @return null|Address
      */
     private function _getAddress($objAddressResult)
     {
+        if (count($objAddressResult) == 1
+            && array_key_exists('nil', $objAddressResult)
+            && $objAddressResult['nil'] == 'true'
+        ) {
+            return null;
+        }
+
         $address = new Address();
 
         $address->setAddress1($objAddressResult['Address1']);


### PR DESCRIPTION
Occurrence of BusinessAddress (and ShippingAddress) in response of command GetOrderList is optional. So according to documentation sometimes response can look like:

```xml
[...]
    <Order>
        <ArchiveParcelList>false</ArchiveParcelList>
        <BillingAddress i:nil="true"/>
        <Corporation i:nil="true"/>
        <CreationDate>2017-11-07T21:22:23.98</CreationDate>
[...]
        <OrderState i:nil="true"/>
    </Order>
[...]
```
In this case i getting notice: Undefined index: Address1
Parsing this response doesn't match the documentation.