### PR TITLE
Better Integration to third party applications

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,11 @@
 ## 1- Install a web server (for example wamp for windows)
 
+This project is an update to the [Cdiscount/API-MarketPlace-SDK-PHP](https://github.com/Cdiscount/API-MarketPlace-SDK-PHP) parent.
+
+Main Changes include the ability to pass in the username, password, token url and cURL options into the API functionality without the need to modify the supplied `config.ini` file.
+
+The reasons for these changes are to better support frameworks like Laravel and to disuade users from directly editing files in the `vendor` directory.
+
 ### 1.1 - Min requirements :
 
 *   Apache 2.2

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
     "name": "autumndev/cdiscount-sdkphpapi",
     "description": "PHP SDK for the Cdiscount Marketplace API",
-    "type": "project",
+    "type": "library",
     "autoload": {
         "files": ["sdk/autoload.php"]
     },
@@ -14,5 +14,5 @@
         "zendframework/zend-config": "^2.6"
     },
     "license": "GPL-3.0",
-    "version": "1.1.9"
+    "version": "1.1.10"
 }

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "cdiscount/sdkphpapi",
+    "name": "autumndev/cdiscount-sdkphpapi",
     "description": "PHP SDK for the Cdiscount Marketplace API",
     "type": "project",
     "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -14,5 +14,5 @@
         "zendframework/zend-config": "^2.6"
     },
     "license": "GPL-3.0",
-    "version": "1.0.8"
+    "version": "1.1.9"
 }

--- a/sdk/autoload.php
+++ b/sdk/autoload.php
@@ -193,6 +193,7 @@ require_once __DIR__ . '/src/core/Soap/SOAPStruct.php';
 require_once __DIR__ . '/src/public/ApiClient/CDSApiClient.php';
 
 require_once __DIR__ . '/src/public/Common/Filter.php';
+require_once __DIR__ . '/src/public/AbstractPoint.php';
 
 
 require_once __DIR__ . '/src/public/Discussion/DiscussionFilter.php';

--- a/sdk/src/core/Auth/Token.php
+++ b/sdk/src/core/Auth/Token.php
@@ -40,6 +40,12 @@ class Token
      * @var string Token to communicate with the API
      */
     private $_token = null;
+    /**
+     * @var string
+     */
+    private $username = null;
+    private $password = null;
+    private $tokenUrl = null;
 
     #endregion Private attributes
 
@@ -48,10 +54,13 @@ class Token
     /**
      * Token constructor.
      */
-    private function __construct()
+    private function __construct(string $username = null, string $password = null, string $tokenUrl = null)
     {
         $this->_isValid = false;
         $this->_initdate = false;
+        $this->username = $username;
+        $this->password = $password;
+        $this->tokenUrl = $tokenUrl;
     }
 
     #endregion Constructor
@@ -62,11 +71,11 @@ class Token
      * Return a unique instance of the token class, initiate it if needed
      * @return Token
      */
-    public static function getInstance()
+    public static function getInstance(string $username = null, string $password = null, string $tokenUrl = null)
     {
 
         if (is_null(self::$_instance)) {
-            self::$_instance = new Token();
+            self::$_instance = new Token($username, $password, $tokenUrl);
         }
         return self::$_instance;
     }
@@ -77,11 +86,17 @@ class Token
 
     private function _generateNewToken()
     {
-        $username = ConfigFileLoader::getInstance()->getConfAttribute('username');
-        $password = ConfigFileLoader::getInstance()->getConfAttribute('password');
-        $urlToken = ConfigFileLoader::getInstance()->getConfAttribute('urltoken');
+        if (null === $this->username) {
+            $this->username = ConfigFileLoader::getInstance()->getConfAttribute('username');
+        }
+        if (null === $this->password) {
+            $this->password = ConfigFileLoader::getInstance()->getConfAttribute('password');
+        }
+        if (null === $this->tokenUrl) {
+            $this->tokenUrl = ConfigFileLoader::getInstance()->getConfAttribute('urltoken');
+        }
 
-        $request = new CDSApiRequest($username, $password, $urlToken);
+        $request = new CDSApiRequest($this->username, $this->password, $this->tokenUrl);
 
         libxml_use_internal_errors(true);
         $xmlResult = simplexml_load_string($request->execute());

--- a/sdk/src/core/HttpTools/CDSApiSoapRequest.php
+++ b/sdk/src/core/HttpTools/CDSApiSoapRequest.php
@@ -31,6 +31,16 @@ class CDSApiSoapRequest
      */
     private $_header = null;
 
+    private $curlOptions = [
+        CURLOPT_VERBOSE => false,
+        CURLOPT_HEADER => true,
+        CURLOPT_POST => true,
+        CURLOPT_SSLVERSION => 4,
+        CURLOPT_SSL_VERIFYPEER => FALSE,
+        CURLOPT_RETURNTRANSFER => TRUE,
+        CURLOPT_TIMEOUT => 600
+    ];
+
     /**
      * CDSApiSoapRequest constructor.
      *
@@ -39,9 +49,9 @@ class CDSApiSoapRequest
      * @param $apiURL
      * @param $data
      */
-    public function __construct($method, $headerMethodURL, $apiURL, $data)
+    public function __construct($method, $headerMethodURL, $apiURL, $data, array $curlOptions = [])
     {
-
+        $this->curlOptions = $curlOptions + $this->curlOptions;
         $this->_client = new \Zend\Http\Client($apiURL);
         $this->_client->setMethod('post');
         $this->_client->setRawBody($data);
@@ -60,19 +70,12 @@ class CDSApiSoapRequest
      * @param $url
      */
     private function _setAdapaterOptions($data, $url)
-    {
+    {   
+        $this->curlOptions[CURLOPT_URL]           = $url;
+        $this->curlOptions[CURLOPT_POSTFIELDS]    = $data;
+
         $this->_adapter->setOptions(array(
-            'curloptions' => array(
-                CURLOPT_URL => $url,
-                CURLOPT_VERBOSE => false,
-                CURLOPT_HEADER => true,
-                CURLOPT_POST => true,
-                CURLOPT_SSLVERSION => 4,
-                CURLOPT_SSL_VERIFYPEER => FALSE,
-                CURLOPT_RETURNTRANSFER => TRUE,
-                CURLOPT_POSTFIELDS => $data,
-                CURLOPT_TIMEOUT => 600
-            )
+            'curloptions' => $this->curlOptions,
         ));
     }
 

--- a/sdk/src/public/AbstractPoint.php
+++ b/sdk/src/public/AbstractPoint.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Sdk;
+
+use Sdk\ConfigTools\ConfigFileLoader;
+use Sdk\HttpTools\CDSApiSoapRequest;
+
+abstract class AbstractPoint
+{
+    /**
+     * api end point urls
+     *
+     * @var string
+     */
+    protected $headerRequestURL = null;
+    protected $apiUrl           = null;
+
+    public function __construct(string $headerRequestURL = null, string $apiUrl = null)
+    {
+        $this->headerRequestURL = $headerRequestURL;
+        if (null === $this->headerRequestURL) {
+            $this->headerRequestURL = ConfigFileLoader::getInstance()->getConfAttribute('methodurl');
+        }
+
+        $this->apiUrl = $apiUrl;
+        if (null === $this->apiUrl) {
+            $this->apiUrl = ConfigFileLoader::getInstance()->getConfAttribute('url');
+        }
+    }
+    /**
+     * @param $method
+     * @param $data
+     * @return string
+     */
+    protected function _sendRequest($method, $data)
+    {
+        $request = new CDSApiSoapRequest($method, $this->headerRequestURL, $this->apiURL, $data);
+        $response = $request->call();
+
+        return $response;
+    }
+}

--- a/sdk/src/public/AbstractPoint.php
+++ b/sdk/src/public/AbstractPoint.php
@@ -14,9 +14,16 @@ abstract class AbstractPoint
      */
     protected $headerRequestURL = null;
     protected $apiUrl           = null;
+    /**
+     * curl options
+     *
+     * @var array
+     */
+    protected $curlOptions  = [];
 
-    public function __construct(string $headerRequestURL = null, string $apiUrl = null)
+    public function __construct(string $headerRequestURL = null, string $apiUrl = null, array $curlOptions = [])
     {
+        $this->curlOptions = $curlOptions;
         $this->headerRequestURL = $headerRequestURL;
         if (null === $this->headerRequestURL) {
             $this->headerRequestURL = ConfigFileLoader::getInstance()->getConfAttribute('methodurl');
@@ -34,7 +41,7 @@ abstract class AbstractPoint
      */
     protected function _sendRequest($method, $data)
     {
-        $request = new CDSApiSoapRequest($method, $this->headerRequestURL, $this->apiURL, $data);
+        $request = new CDSApiSoapRequest($method, $this->headerRequestURL, $this->apiUrl, $data, $this->curlOptions);
         $response = $request->call();
 
         return $response;

--- a/sdk/src/public/ApiClient/CDSApiClient.php
+++ b/sdk/src/public/ApiClient/CDSApiClient.php
@@ -33,13 +33,15 @@ class CDSApiClient
     private $apiUrl = null;
     private $methodUrl = null;
 
+    private $curlOptions = [];
+
     /**
      * @return SellerPoint
      */
     public function getSellerPoint()
     {
         if ($this->_sellerPoint == null) {
-            $this->_sellerPoint = new SellerPoint($this->methodUrl, $this->apiUrl);
+            $this->_sellerPoint = new SellerPoint($this->methodUrl, $this->apiUrl, $this->curlOptions);
         }
         return $this->_sellerPoint;
     }
@@ -55,7 +57,7 @@ class CDSApiClient
     public function getOrderPoint()
     {
         if ($this->_orderPoint == null) {
-            $this->_orderPoint = new OrderPoint($this->methodUrl, $this->apiUrl);
+            $this->_orderPoint = new OrderPoint($this->methodUrl, $this->apiUrl, $this->curlOptions);
         }
         return $this->_orderPoint;
     }
@@ -71,7 +73,7 @@ class CDSApiClient
     public function getOfferPoint()
     {
         if ($this->_offerPoint == null) {
-            $this->_offerPoint = new OfferPoint($this->methodUrl, $this->apiUrl);
+            $this->_offerPoint = new OfferPoint($this->methodUrl, $this->apiUrl, $this->curlOptions);
         }
         return $this->_offerPoint;
     }
@@ -87,7 +89,7 @@ class CDSApiClient
     public function getProductPoint()
     {
         if ($this->_productPoint == null) {
-            $this->_productPoint = new ProductPoint($this->methodUrl, $this->apiUrl);
+            $this->_productPoint = new ProductPoint($this->methodUrl, $this->apiUrl, $this->curlOptions);
         }
         return $this->_productPoint;
     }
@@ -103,7 +105,7 @@ class CDSApiClient
     public function getFulfilmentPoint()
     {
         if ($this->_fulfilmentPoint == null) {
-            $this->_fulfilmentPoint = new FulfilmentPoint($this->methodUrl, $this->apiUrl);
+            $this->_fulfilmentPoint = new FulfilmentPoint($this->methodUrl, $this->apiUrl, $this->curlOptions);
         }
         return $this->_fulfilmentPoint;
     }
@@ -119,7 +121,7 @@ class CDSApiClient
     public function getDiscussionPoint()
     {
         if ($this->_discussionPoint == null) {
-            $this->_discussionPoint = new DiscussionPoint($this->methodUrl, $this->apiUrl);
+            $this->_discussionPoint = new DiscussionPoint($this->methodUrl, $this->apiUrl, $this->curlOptions);
         }
         return $this->_discussionPoint;
     }
@@ -135,7 +137,7 @@ class CDSApiClient
     public function getRelaysPoint()
     {
         if ($this->_relaysPoint == null) {
-            $this->_relaysPoint = new RelaysPoint($this->methodUrl, $this->apiUrl);
+            $this->_relaysPoint = new RelaysPoint($this->methodUrl, $this->apiUrl, $this->curlOptions);
         }
         return $this->_relaysPoint;
     }
@@ -151,7 +153,7 @@ class CDSApiClient
     public function getMailPoint()
     {
         if ($this->_mailPoint == null) {
-            $this->_mailPoint = new MailPoint($this->methodUrl, $this->apiUrl);
+            $this->_mailPoint = new MailPoint($this->methodUrl, $this->apiUrl, $this->curlOptions);
         }
         return $this->_mailPoint;
     }
@@ -159,10 +161,11 @@ class CDSApiClient
     /**
      * Create and check the token
      */
-    public function init(string $username = null, string $password = null, string $tokenUrl = null, string $apiUrl = null, string $methodUrl = null)
+    public function init(string $username = null, string $password = null, string $tokenUrl = null, string $apiUrl = null, string $methodUrl = null, array $curlOptions = [])
     {
         $this->apiUrl = $apiUrl;
         $this->methodUrl = $methodUrl;
+        $this->curlOptions = $curlOptions;
         $token = Token::getInstance($username, $password, $tokenUrl)->getToken();
         return $token;
     }

--- a/sdk/src/public/ApiClient/CDSApiClient.php
+++ b/sdk/src/public/ApiClient/CDSApiClient.php
@@ -30,13 +30,16 @@ class CDSApiClient
      */
     private $_sellerPoint = null;
 
+    private $apiUrl = null;
+    private $methodUrl = null;
+
     /**
      * @return SellerPoint
      */
     public function getSellerPoint()
     {
         if ($this->_sellerPoint == null) {
-            $this->_sellerPoint = new SellerPoint();
+            $this->_sellerPoint = new SellerPoint($this->methodUrl, $this->apiUrl);
         }
         return $this->_sellerPoint;
     }
@@ -52,7 +55,7 @@ class CDSApiClient
     public function getOrderPoint()
     {
         if ($this->_orderPoint == null) {
-            $this->_orderPoint = new OrderPoint();
+            $this->_orderPoint = new OrderPoint($this->methodUrl, $this->apiUrl);
         }
         return $this->_orderPoint;
     }
@@ -68,7 +71,7 @@ class CDSApiClient
     public function getOfferPoint()
     {
         if ($this->_offerPoint == null) {
-            $this->_offerPoint = new OfferPoint();
+            $this->_offerPoint = new OfferPoint($this->methodUrl, $this->apiUrl);
         }
         return $this->_offerPoint;
     }
@@ -84,7 +87,7 @@ class CDSApiClient
     public function getProductPoint()
     {
         if ($this->_productPoint == null) {
-            $this->_productPoint = new ProductPoint();
+            $this->_productPoint = new ProductPoint($this->methodUrl, $this->apiUrl);
         }
         return $this->_productPoint;
     }
@@ -100,7 +103,7 @@ class CDSApiClient
     public function getFulfilmentPoint()
     {
         if ($this->_fulfilmentPoint == null) {
-            $this->_fulfilmentPoint = new FulfilmentPoint();
+            $this->_fulfilmentPoint = new FulfilmentPoint($this->methodUrl, $this->apiUrl);
         }
         return $this->_fulfilmentPoint;
     }
@@ -116,7 +119,7 @@ class CDSApiClient
     public function getDiscussionPoint()
     {
         if ($this->_discussionPoint == null) {
-            $this->_discussionPoint = new DiscussionPoint();
+            $this->_discussionPoint = new DiscussionPoint($this->methodUrl, $this->apiUrl);
         }
         return $this->_discussionPoint;
     }
@@ -132,7 +135,7 @@ class CDSApiClient
     public function getRelaysPoint()
     {
         if ($this->_relaysPoint == null) {
-            $this->_relaysPoint = new RelaysPoint();
+            $this->_relaysPoint = new RelaysPoint($this->methodUrl, $this->apiUrl);
         }
         return $this->_relaysPoint;
     }
@@ -148,7 +151,7 @@ class CDSApiClient
     public function getMailPoint()
     {
         if ($this->_mailPoint == null) {
-            $this->_mailPoint = new MailPoint();
+            $this->_mailPoint = new MailPoint($this->methodUrl, $this->apiUrl);
         }
         return $this->_mailPoint;
     }
@@ -156,9 +159,11 @@ class CDSApiClient
     /**
      * Create and check the token
      */
-    public function init()
+    public function init(string $username = null, string $password = null, string $tokenUrl = null, string $apiUrl = null, string $methodUrl = null)
     {
-        $token = Token::getInstance()->getToken();
+        $this->apiUrl = $apiUrl;
+        $this->methodUrl = $methodUrl;
+        $token = Token::getInstance($username, $password, $tokenUrl)->getToken();
         return $token;
     }
 

--- a/sdk/src/public/Discussion/DiscussionPoint.php
+++ b/sdk/src/public/Discussion/DiscussionPoint.php
@@ -8,8 +8,7 @@
 
 namespace Sdk\Discussion;
 
-use Sdk\ConfigTools\ConfigFileLoader;
-use Sdk\HttpTools\CDSApiSoapRequest;
+use Sdk\AbstractPoint;
 use Sdk\Soap\Common\Body;
 use Sdk\Soap\Common\Envelope;
 use Sdk\Soap\Discussion\ClaimFilterSoap;
@@ -25,7 +24,7 @@ use Sdk\Soap\Discussion\Response\GetOrderClaimListResponse;
 use Sdk\Soap\Discussion\Response\GetOrderQuestionListResponse;
 use Sdk\Soap\HeaderMessage\HeaderMessage;
 
-class DiscussionPoint
+class DiscussionPoint extends AbstractPoint
 {
 
     /**
@@ -151,24 +150,4 @@ class DiscussionPoint
 
         return $envelopeXML;
     }
-
-    /**
-     * @param $method
-     * @param $data
-     * @return string
-     */
-    private function _sendRequest($method, $data)
-    {
-        $headerRequestURL = ConfigFileLoader::getInstance()->getConfAttribute('methodurl');
-
-        $apiURL = ConfigFileLoader::getInstance()->getConfAttribute('url');
-
-        $request = new CDSApiSoapRequest($method, $headerRequestURL, $apiURL, $data);
-        $response = $request->call();
-
-        return $response;
-    }
-
-
-
 }

--- a/sdk/src/public/Fulfilment/FulfilmentPoint.php
+++ b/sdk/src/public/Fulfilment/FulfilmentPoint.php
@@ -6,9 +6,7 @@
 
 namespace Sdk\Fulfilment;
 
-
-use Sdk\ConfigTools\ConfigFileLoader;
-use Sdk\HttpTools\CDSApiSoapRequest;
+use Sdk\AbstractPoint;
 use Sdk\Soap\Common\Body;
 use Sdk\Soap\Common\Envelope;
 use Sdk\Soap\Fulfillment\CreateExternalOrderSoap;
@@ -40,7 +38,7 @@ use Sdk\Soap\Fulfilment\Response\GetFulfilmentActivationReportRequestXmlResponse
 /*
  * Fulfilment point
  */
-class FulfilmentPoint
+class FulfilmentPoint extends AbstractPoint
 {
     public function __construct()
     {
@@ -357,23 +355,5 @@ class FulfilmentPoint
         $FulfilmentActivationReportRequestXmlResponse = new GetFulfilmentActivationReportRequestXmlResponse($response);
 
         return $FulfilmentActivationReportRequestXmlResponse;
-    }
-
-    /*
-     * @param $method
-     * @param $data
-     * @return $response
-     */
-    private function _sendRequest($method, $data)
-    {
-        $headerRequestURL = ConfigFileLoader::getInstance()->getConfAttribute('methodurl');
-
-        $apiURL = ConfigFileLoader::getInstance()->getConfAttribute('url');
-
-        $request = new CDSApiSoapRequest($method, $headerRequestURL, $apiURL, $data);
-
-        $response = $request->call();
-
-        return $response;
     }
 }

--- a/sdk/src/public/Mail/MailPoint.php
+++ b/sdk/src/public/Mail/MailPoint.php
@@ -8,9 +8,7 @@
 
 namespace Sdk\Mail;
 
-
-use Sdk\ConfigTools\ConfigFileLoader;
-use Sdk\HttpTools\CDSApiSoapRequest;
+use Sdk\AbstractPoint;
 use Sdk\Soap\Common\Body;
 use Sdk\Soap\Common\Envelope;
 use Sdk\Soap\HeaderMessage\HeaderMessage;
@@ -20,7 +18,7 @@ use Sdk\Soap\Mail\Request;
 use Sdk\Soap\Mail\Response\GenerateDiscussionMailGuidResponse;
 use Sdk\Soap\Mail\Response\GetDiscussionMailListResponse;
 
-class MailPoint
+class MailPoint extends AbstractPoint
 {
 
     /**
@@ -71,22 +69,5 @@ class MailPoint
 
         $generateDiscussionMailGuidResponse = new GenerateDiscussionMailGuidResponse($response);
         return $generateDiscussionMailGuidResponse;
-    }
-
-    /**
-     * @param $method
-     * @param $data
-     * @return string
-     */
-    private function _sendRequest($method, $data)
-    {
-        $headerRequestURL = ConfigFileLoader::getInstance()->getConfAttribute('methodurl');
-
-        $apiURL = ConfigFileLoader::getInstance()->getConfAttribute('url');
-
-        $request = new CDSApiSoapRequest($method, $headerRequestURL, $apiURL, $data);
-        $response = $request->call();
-
-        return $response;
     }
 }

--- a/sdk/src/public/Offer/OfferPoint.php
+++ b/sdk/src/public/Offer/OfferPoint.php
@@ -1,8 +1,8 @@
 <?php
 
 namespace Sdk\Offer;
-use Sdk\ConfigTools\ConfigFileLoader;
-use Sdk\HttpTools\CDSApiSoapRequest;
+
+use Sdk\AbstractPoint;
 use Sdk\Soap\Common\Body;
 use Sdk\Soap\Common\Envelope;
 use Sdk\Soap\HeaderMessage\HeaderMessage;
@@ -23,7 +23,7 @@ use Sdk\Soap\Offer\SubmitOfferPackage;
  * Date: 13/10/2016
  * Time: 15:15
  */
-class OfferPoint
+class OfferPoint extends AbstractPoint
 {
 
     /**
@@ -135,22 +135,5 @@ class OfferPoint
 
         $getOfferPackageSubmissionResultResponse = new GetOfferPackageSubmissionResultResponse($response);
         return $getOfferPackageSubmissionResultResponse;
-    }
-
-    /**
-     * @param $method
-     * @param $data
-     * @return string
-     */
-    private function _sendRequest($method, $data)
-    {
-        $headerRequestURL = ConfigFileLoader::getInstance()->getConfAttribute('methodurl');
-
-        $apiURL = ConfigFileLoader::getInstance()->getConfAttribute('url');
-
-        $request = new CDSApiSoapRequest($method, $headerRequestURL, $apiURL, $data);
-        $response = $request->call();
-
-        return $response;
     }
 }

--- a/sdk/src/public/Order/OrderPoint.php
+++ b/sdk/src/public/Order/OrderPoint.php
@@ -8,9 +8,7 @@
 
 namespace Sdk\Order;
 
-
-use Sdk\ConfigTools\ConfigFileLoader;
-use Sdk\HttpTools\CDSApiSoapRequest;
+use Sdk\AbstractPoint;
 use Sdk\Soap\Common\Body;
 use Sdk\Soap\Common\Envelope;
 use Sdk\Soap\HeaderMessage\HeaderMessage;
@@ -27,7 +25,7 @@ use Sdk\Soap\Order\Response\ManageParcelResponse;
 use Sdk\Soap\Order\ValidateOrderList;
 use Sdk\Soap\Order\ValidateOrderListResponse;
 
-class OrderPoint
+class OrderPoint extends AbstractPoint
 {
     /**
      * @param $order \Sdk\Order\OrderList
@@ -180,15 +178,4 @@ class OrderPoint
 
         return new CreateRefundVoucherResponse($response);
     }
-
-    private function _sendRequest($method, $data)
-    {
-        $headerRequestURL = ConfigFileLoader::getInstance()->getConfAttribute('methodurl');
-
-        $apiURL = ConfigFileLoader::getInstance()->getConfAttribute('url');
-
-        $request = new CDSApiSoapRequest($method, $headerRequestURL, $apiURL, $data);
-        return $request->call();
-    }
-
 }

--- a/sdk/src/public/Product/ProductPoint.php
+++ b/sdk/src/public/Product/ProductPoint.php
@@ -8,9 +8,7 @@
 
 namespace Sdk\Product;
 
-
-use Sdk\ConfigTools\ConfigFileLoader;
-use Sdk\HttpTools\CDSApiSoapRequest;
+use Sdk\AbstractPoint;
 use Sdk\Soap\Common\Body;
 use Sdk\Soap\Common\Envelope;
 use Sdk\Soap\HeaderMessage\HeaderMessage;
@@ -41,7 +39,7 @@ use Sdk\Soap\Product\SubmitProductPackage;
 /*
  * Product point
  */
-class ProductPoint
+class ProductPoint extends AbstractPoint
 {
     /**
      * @return GetProductListByIdentifierResponse
@@ -261,22 +259,4 @@ class ProductPoint
 
         return new GetProductPackageProductMatchingFileDataResponse($response);
     }
-
-    /**
-     * @param $method
-     * @param $data
-     * @return mixed
-     */
-    private function _sendRequest($method, $data)
-    {
-        $headerRequestURL = ConfigFileLoader::getInstance()->getConfAttribute('methodurl');
-
-        $apiURL = ConfigFileLoader::getInstance()->getConfAttribute('url');
-
-        $request = new CDSApiSoapRequest($method, $headerRequestURL, $apiURL, $data);
-
-        return $request->call();
-    }
-
-
 }

--- a/sdk/src/public/Relays/RelaysPoint.php
+++ b/sdk/src/public/Relays/RelaysPoint.php
@@ -8,15 +8,13 @@
 
 namespace Sdk\Relays;
 
-
-use Sdk\ConfigTools\ConfigFileLoader;
-use Sdk\HttpTools\CDSApiSoapRequest;
+use Sdk\AbstractPoint;
 use Sdk\Soap\Common\Body;
 use Sdk\Soap\Common\Envelope;
 use Sdk\Soap\HeaderMessage\HeaderMessage;
 use Sdk\Soap\Relays\GetParcelShopList;
 
-class RelaysPoint
+class RelaysPoint extends AbstractPoint
 {
 
     /**
@@ -38,21 +36,5 @@ class RelaysPoint
 
         //$getProductPackageSubmissionResultResponse = new GetProductPackageSubmissionResultResponse($response);
         //return $getProductPackageSubmissionResultResponse;
-    }
-
-    /**
-     * @param $method
-     * @param $data
-     * @return mixed
-     */
-    private function _sendRequest($method, $data)
-    {
-        $headerRequestURL = ConfigFileLoader::getInstance()->getConfAttribute('methodurl');
-
-        $apiURL = ConfigFileLoader::getInstance()->getConfAttribute('url');
-
-        $request = new CDSApiSoapRequest($method, $headerRequestURL, $apiURL, $data);
-
-        return $request->call();
     }
 }

--- a/sdk/src/public/Seller/SellerPoint.php
+++ b/sdk/src/public/Seller/SellerPoint.php
@@ -7,8 +7,8 @@
  */
 
 namespace Sdk\Seller;
-use Sdk\ConfigTools\ConfigFileLoader;
-use Sdk\HttpTools\CDSApiSoapRequest;
+
+use Sdk\AbstractPoint;
 use Sdk\Soap\Common\Body;
 use Sdk\Soap\Common\Envelope;
 use Sdk\Soap\HeaderMessage\HeaderMessage;
@@ -21,7 +21,7 @@ use Sdk\Soap\Seller\Response\GetSellerIndicatorsResponse;
  * Class SellerPoint
  * @package Seller
  */
-class SellerPoint
+class SellerPoint extends AbstractPoint
 {
     /**
      * @return GetSellerInformationResponse
@@ -61,21 +61,5 @@ class SellerPoint
         $response = $this->_sendRequest('GetSellerIndicators', $envelopeXML);
 
         return new GetSellerIndicatorsResponse($response);
-    }
-
-    /**
-     * @param $method
-     * @param $data
-     * @return string
-     */
-    private function _sendRequest($method, $data)
-    {
-        $headerRequestURL = ConfigFileLoader::getInstance()->getConfAttribute('methodurl');
-
-        $apiURL = ConfigFileLoader::getInstance()->getConfAttribute('url');
-
-        $request = new CDSApiSoapRequest($method, $headerRequestURL, $apiURL, $data);
-
-        return $request->call();
     }
 }


### PR DESCRIPTION
A lot of applications use their own configuration fiels (Laravel, craft etc)

The changes here allow a user to pass in parameters rather than rely on a config file in their vendor directory - which will be overwritten on update. User can pass:
- Username
- Password
- Token Url
- cURL options

I have added default cURL options but allowed the user to overwrite them due to differences in the preprod and live systems for exampel preprod does not like cURL version 4 and wont work if that is supplied (Version 1 is required). 

I have also condensed some (not all) common functionality (AbstractPoint) for easier maintainability.